### PR TITLE
Fix looks balance formatting

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -117,7 +117,10 @@ function App() {
     const looksRewardsToday = stateStakingInfo.totalLooksToDistribute * percentOfStake;
     return {
       ...stateBalance,
-      looksShares: convertPrice(Number(looksShares)),
+      looksShares: Number(stateStakingInfo.totalLooksToDistribute).toLocaleString(undefined, {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0
+      }),
       looksSharesInUSD: convertPrice(Number(price * looksShares)),
       looksSharesInETH: Number(price * looksShares / ethPrice).toLocaleString(undefined, {
         style: 'currency',

--- a/src/App.js
+++ b/src/App.js
@@ -117,7 +117,7 @@ function App() {
     const looksRewardsToday = stateStakingInfo.totalLooksToDistribute * percentOfStake;
     return {
       ...stateBalance,
-      looksShares: Number(stateStakingInfo.totalLooksToDistribute).toLocaleString(undefined, {
+      looksShares: Number(looksShares).toLocaleString(undefined, {
         minimumFractionDigits: 0,
         maximumFractionDigits: 0
       }),


### PR DESCRIPTION
Looks balance was being formatted into currency. Matches formatting to other LOOKS formatting usages.

from:
![image](https://user-images.githubusercontent.com/97764360/150244172-48ccf1dd-b7ad-4e94-8700-239da425e23a.png)

to:
![image](https://user-images.githubusercontent.com/97764360/150244375-d0051110-4e7f-4ada-8439-9b5bf5db5681.png)